### PR TITLE
Export ParseDeviceInfo

### DIFF
--- a/appattest/device_info.go
+++ b/appattest/device_info.go
@@ -56,10 +56,10 @@ type DeviceInfo struct {
 	BuildVariant string
 }
 
-// parseDeviceInfo attempts to extract DeviceInfo from the leaf certificate.
+// ParseDeviceInfo attempts to extract DeviceInfo from the leaf certificate.
 // Returns nil if the extension is not present. Parsing is best-effort:
 // unrecognized or malformed fields are silently skipped.
-func parseDeviceInfo(cert *x509.Certificate) *DeviceInfo {
+func ParseDeviceInfo(cert *x509.Certificate) *DeviceInfo {
 	var extValue []byte
 	for _, ext := range cert.Extensions {
 		if ext.Id.Equal(oidDeviceInfo) {

--- a/appattest/verify_attestation.go
+++ b/appattest/verify_attestation.go
@@ -135,7 +135,7 @@ func VerifyAttestationPure(in *VerifyAttestationInputPure) (VerifyAttestationOut
 		BundleDigest:    authenticatorData.RelayingPartyHash,
 		KeyID:           computedPubkeyHash[:],
 
-		DeviceInfo: parseDeviceInfo(leafCert),
+		DeviceInfo: ParseDeviceInfo(leafCert),
 	}, nil
 }
 


### PR DESCRIPTION
## Problem

`parseDeviceInfo` is unexported, so callers that need to extract Apple device info from a certificate without running full attestation verification can't use it.

## Fix

Export `parseDeviceInfo` → `ParseDeviceInfo`.

### Key Changes
- **device_info.go** - Renamed `parseDeviceInfo` to `ParseDeviceInfo`
- **verify_attestation.go** - Updated internal call site

## Validation

`go build ./...` and `go test ./...` pass.

## Impact

Non-breaking — adds a new exported symbol. Existing callers via `VerifyAttestationOutput.DeviceInfo` are unaffected.

## Drawbacks

None.